### PR TITLE
Add personal-thumbnailer-cache plug

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -14,6 +14,13 @@ slots:
     bus: session
     name: org.gnome.Cheese
 
+plugs:
+  # for the image switcher at the bottom of cheese
+  personal-thumbnail-cache:
+    interface: personal-files
+    write:
+    - $HOME/.cache/thumbnails
+
 apps:
   cheese:
     extensions: [ gnome-3-38 ]
@@ -23,6 +30,7 @@ apps:
       - audio-playback
       - camera
       - home
+      - personal-thumbnail-cache
     environment:
       DISABLE_WAYLAND: 'true'
 


### PR DESCRIPTION
The previous commit didn't seem to fix the thumbnailer view in the bottom panel of cheese. Here is another attempt. In my testing, it seemed to work even without the interface being connected. Which doesn't seem right to me.

Remaining issue
----------------------
Cheese not only takes photos, it takes videos too, but the videos aren't thumbnailed. It looks like totem-common provides a thumbnailer that can do that in a traditional Ubuntu install.