### PR TITLE
bump automation extension version

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -32,7 +32,7 @@ parts:
     source-tag: '44.1'
 # ext:updatesnap
 #   version-format:
-#     lower-than: 45.0
+#     lower-than: 46.0
     source-depth: 1
     parse-info: [usr/share/metainfo/org.gnome.Cheese.appdata.xml]
     override-build: |


### PR DESCRIPTION
bumping automation extension version to pull gnome 45 tags